### PR TITLE
perf: request cache get_schedule_for_user

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[2.5.1] - 2024-08-06
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Reduce schedule queries by using a request cache for get_schedule_for_user.
+
 [2.5.0] - 2024-04-02
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Add support for Python 3.11. Dropped django32 support.

--- a/edx_when/__init__.py
+++ b/edx_when/__init__.py
@@ -2,4 +2,4 @@
 Central source of course block dates for the LMS.
 """
 
-__version__ = '2.5.0'
+__version__ = '2.5.1'

--- a/edx_when/api.py
+++ b/edx_when/api.py
@@ -193,7 +193,7 @@ def get_dates_for_course(
             user_id = user.id if not user.is_anonymous else ''
 
     if schedule is None and user is not None and user_id != '':
-        schedule = get_schedule_for_user(user_id, course_id)
+        schedule = get_schedule_for_user(user_id, course_id, use_cached=use_cached)
 
     # Construct the cache key, incorporating all parameters which would cause a different
     # query set to be returned.

--- a/edx_when/utils.py
+++ b/edx_when/utils.py
@@ -2,6 +2,7 @@
 Utility functions to use across edx-when.
 """
 from django.core.exceptions import ObjectDoesNotExist
+from edx_django_utils.cache.utils import RequestCache
 
 try:
     from openedx.core.djangoapps.schedules.models import Schedule
@@ -10,13 +11,34 @@ except ImportError:
     Schedule = None
 
 
-def get_schedule_for_user(user_id, course_key):
+def get_schedule_for_user(user_id, course_key, use_cached=True):
     """
     Return the schedule for the user in the course or None if it does not exist or the Schedule model is undefined.
     """
-    if Schedule:
-        try:
-            return Schedule.objects.get(enrollment__user__id=user_id, enrollment__course__id=course_key)
-        except ObjectDoesNotExist:
-            pass
-    return None
+    # If Schedule is not defined, there's nothing to query, so return None. This
+    # hackiness is happening because the Schedule model is in edx-platform at
+    # the moment.
+    if not Schedule:
+        return None
+
+    # This is intentionally a RequestCache and not a TieredCache–that way it's
+    # just a local memory reference, and we don't have to worry about the
+    # complications that can come with pickling model objects.
+    cache = RequestCache('edx-when')
+    cache_key = f"get_schedule_for_user::{user_id}::{course_key}"
+    if use_cached:
+        cache_response = cache.get_cached_response(cache_key)
+        if cache_response.is_found:
+            return cache_response.value
+
+    try:
+        schedule = Schedule.objects.get(
+            enrollment__user__id=user_id,
+            enrollment__course__id=course_key,
+        )
+    except ObjectDoesNotExist:
+        schedule = None
+
+    cache.set(cache_key, schedule)
+
+    return schedule


### PR DESCRIPTION
Calls to render a Unit were calling this function many times, even when
schedules are not enabled. This was leading to noticeable performance
issues in production, particularly for Units with many components.

I still need to test this properly, which is probably going to involve
hacky looking mocking because of the weird model relationship this has
with edx-platform (where it's actually importing the Schedule model
from edx-platform).
