### PR TITLE
chore: Dropped support for Python 3.8 and added support for Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,9 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.0.0] - 2025-05-15
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Dropped support for Python 3.8.
+* Added support for Python 3.12.
+
 [2.5.1] - 2024-08-06
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Reduce schedule queries by using a request cache for get_schedule_for_user.

--- a/edx_when/__init__.py
+++ b/edx_when/__init__.py
@@ -2,4 +2,4 @@
 Central source of course block dates for the LMS.
 """
 
-__version__ = '2.6.0'
+__version__ = '3.0.0'

--- a/pylintrc
+++ b/pylintrc
@@ -380,6 +380,6 @@ ext-import-graph =
 int-import-graph = 
 
 [EXCEPTIONS]
-overgeneral-exceptions = Exception
+overgeneral-exceptions = builtins.Exception
 
 # 264bfbfd3e646c58ffea0db9e4f1e268f0c8704d

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,13 +14,13 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
-click==8.1.8
+click==8.2.0
     # via edx-django-utils
-cryptography==44.0.2
+cryptography==44.0.3
     # via pyjwt
-django==4.2.20
+django==4.2.21
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
@@ -69,7 +69,7 @@ markupsafe==3.0.2
     # via
     #   mako
     #   xblock
-newrelic==10.10.0
+newrelic==10.12.0
     # via edx-django-utils
 pbr==6.1.1
     # via stevedore
@@ -81,7 +81,7 @@ pyjwt[crypto]==2.10.1
     # via
     #   drf-jwt
     #   edx-drf-extensions
-pymongo==4.12.0
+pymongo==4.13.0
     # via edx-opaque-keys
 pynacl==1.5.0
     # via edx-django-utils
@@ -113,7 +113,7 @@ urllib3==2.2.3
     # via
     #   -c requirements/common_constraints.txt
     #   requests
-web-fragments==3.0.0
+web-fragments==3.1.0
     # via xblock
 webob==1.8.9
     # via xblock

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -10,7 +10,7 @@ certifi==2025.4.26
     # via requests
 chardet==5.2.0
     # via tox
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
 codecov==2.1.13
     # via -r requirements/ci.in
@@ -30,21 +30,21 @@ packaging==25.0
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.3.7
+platformdirs==4.3.8
     # via
     #   tox
     #   virtualenv
-pluggy==1.5.0
+pluggy==1.6.0
     # via tox
-pyproject-api==1.9.0
+pyproject-api==1.9.1
     # via tox
 requests==2.32.3
     # via codecov
-tox==4.25.0
+tox==4.26.0
     # via -r requirements/ci.in
 urllib3==2.2.3
     # via
     #   -c requirements/common_constraints.txt
     #   requests
-virtualenv==20.30.0
+virtualenv==20.31.2
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,7 +12,7 @@ asgiref==3.8.1
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==3.3.9
+astroid==3.3.10
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -30,11 +30,11 @@ cffi==1.17.1
     #   -r requirements/quality.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -r requirements/quality.txt
     #   requests
-click==8.1.8
+click==8.2.0
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
@@ -55,7 +55,7 @@ coverage[toml]==7.8.0
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
-cryptography==44.0.2
+cryptography==44.0.3
     # via
     #   -r requirements/quality.txt
     #   pyjwt
@@ -69,7 +69,7 @@ dill==0.4.0
     # via
     #   -r requirements/quality.txt
     #   pylint
-django==4.2.20
+django==4.2.21
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/quality.txt
@@ -111,7 +111,7 @@ edx-django-utils==7.4.0
     #   edx-drf-extensions
 edx-drf-extensions==10.6.0
     # via -r requirements/quality.txt
-edx-i18n-tools==1.8.0
+edx-i18n-tools==1.9.0
     # via -r requirements/dev.in
 edx-lint==5.6.0
     # via -r requirements/quality.txt
@@ -127,7 +127,7 @@ idna==3.10
     # via
     #   -r requirements/quality.txt
     #   requests
-importlib-metadata==8.6.1
+importlib-metadata==8.7.0
     # via path-py
 inflect==7.5.0
     # via jinja2-pluralize
@@ -173,7 +173,7 @@ mock==5.2.0
     # via -r requirements/quality.txt
 more-itertools==10.7.0
     # via inflect
-newrelic==10.10.0
+newrelic==10.12.0
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
@@ -193,11 +193,11 @@ pbr==6.1.1
     #   stevedore
 pip-tools==7.4.1
     # via -r requirements/pip-tools.txt
-platformdirs==4.3.7
+platformdirs==4.3.8
     # via
     #   -r requirements/quality.txt
     #   pylint
-pluggy==1.5.0
+pluggy==1.6.0
     # via
     #   -r requirements/quality.txt
     #   diff-cover
@@ -223,7 +223,7 @@ pyjwt[crypto]==2.10.1
     #   -r requirements/quality.txt
     #   drf-jwt
     #   edx-drf-extensions
-pylint==3.3.6
+pylint==3.3.7
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -243,7 +243,7 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/quality.txt
     #   pylint-celery
     #   pylint-django
-pymongo==4.12.0
+pymongo==4.13.0
     # via
     #   -r requirements/quality.txt
     #   edx-opaque-keys
@@ -301,7 +301,7 @@ six==1.17.0
     #   edx-lint
     #   fs
     #   python-dateutil
-snowballstemmer==2.2.0
+snowballstemmer==3.0.1
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
@@ -335,7 +335,7 @@ urllib3==2.2.3
     #   -c requirements/common_constraints.txt
     #   -r requirements/quality.txt
     #   requests
-web-fragments==3.0.0
+web-fragments==3.1.0
     # via
     #   -r requirements/quality.txt
     #   xblock

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -33,11 +33,11 @@ cffi==1.17.1
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -r requirements/test.txt
     #   requests
-click==8.1.8
+click==8.2.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -48,13 +48,13 @@ coverage[toml]==7.8.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==44.0.2
+cryptography==44.0.3
     # via
     #   -r requirements/test.txt
     #   pyjwt
 ddt==1.7.2
     # via -r requirements/test.txt
-django==4.2.20
+django==4.2.21
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/test.txt
@@ -120,7 +120,7 @@ idna==3.10
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.6.1
+importlib-metadata==8.7.0
     # via keyring
 iniconfig==2.1.0
     # via
@@ -163,7 +163,7 @@ more-itertools==10.7.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-newrelic==10.10.0
+newrelic==10.12.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -180,7 +180,7 @@ pbr==6.1.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-pluggy==1.5.0
+pluggy==1.6.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -207,7 +207,7 @@ pyjwt[crypto]==2.10.1
     #   -r requirements/test.txt
     #   drf-jwt
     #   edx-drf-extensions
-pymongo==4.12.0
+pymongo==4.13.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -274,7 +274,7 @@ six==1.17.0
     #   -r requirements/test.txt
     #   fs
     #   python-dateutil
-snowballstemmer==2.2.0
+snowballstemmer==3.0.1
     # via sphinx
 soupsieve==2.7
     # via beautifulsoup4
@@ -326,7 +326,7 @@ urllib3==2.2.3
     #   -r requirements/test.txt
     #   requests
     #   twine
-web-fragments==3.0.0
+web-fragments==3.1.0
     # via
     #   -r requirements/test.txt
     #   xblock

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,7 +6,7 @@
 #
 build==1.2.2.post1
     # via pip-tools
-click==8.1.8
+click==8.2.0
     # via pip-tools
 packaging==25.0
     # via build

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -12,5 +12,5 @@ pip==24.2
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==79.0.1
+setuptools==80.7.1
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -12,7 +12,7 @@ asgiref==3.8.1
     # via
     #   -r requirements/test.txt
     #   django
-astroid==3.3.9
+astroid==3.3.10
     # via
     #   pylint
     #   pylint-celery
@@ -25,11 +25,11 @@ cffi==1.17.1
     #   -r requirements/test.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -r requirements/test.txt
     #   requests
-click==8.1.8
+click==8.2.0
     # via
     #   -r requirements/test.txt
     #   click-log
@@ -46,7 +46,7 @@ coverage[toml]==7.8.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==44.0.2
+cryptography==44.0.3
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -54,7 +54,7 @@ ddt==1.7.2
     # via -r requirements/test.txt
 dill==0.4.0
     # via pylint
-django==4.2.20
+django==4.2.21
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/test.txt
@@ -139,7 +139,7 @@ mccabe==0.7.0
     # via pylint
 mock==5.2.0
     # via -r requirements/test.txt
-newrelic==10.10.0
+newrelic==10.12.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -151,9 +151,9 @@ pbr==6.1.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==4.3.7
+platformdirs==4.3.8
     # via pylint
-pluggy==1.5.0
+pluggy==1.6.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -174,7 +174,7 @@ pyjwt[crypto]==2.10.1
     #   -r requirements/test.txt
     #   drf-jwt
     #   edx-drf-extensions
-pylint==3.3.6
+pylint==3.3.7
     # via
     #   edx-lint
     #   pylint-celery
@@ -188,7 +188,7 @@ pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==4.12.0
+pymongo==4.13.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -240,7 +240,7 @@ six==1.17.0
     #   edx-lint
     #   fs
     #   python-dateutil
-snowballstemmer==2.2.0
+snowballstemmer==3.0.1
     # via pydocstyle
 sqlparse==0.5.3
     # via
@@ -267,7 +267,7 @@ urllib3==2.2.3
     #   -c requirements/common_constraints.txt
     #   -r requirements/test.txt
     #   requests
-web-fragments==3.0.0
+web-fragments==3.1.0
     # via
     #   -r requirements/test.txt
     #   xblock

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -21,11 +21,11 @@ cffi==1.17.1
     #   -r requirements/base.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.1.8
+click==8.2.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -34,7 +34,7 @@ code-annotations==2.3.0
     # via -r requirements/test.in
 coverage[toml]==7.8.0
     # via pytest-cov
-cryptography==44.0.2
+cryptography==44.0.3
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -112,7 +112,7 @@ markupsafe==3.0.2
     #   xblock
 mock==5.2.0
     # via -r requirements/test.in
-newrelic==10.10.0
+newrelic==10.12.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -122,7 +122,7 @@ pbr==6.1.1
     # via
     #   -r requirements/base.txt
     #   stevedore
-pluggy==1.5.0
+pluggy==1.6.0
     # via pytest
 psutil==7.0.0
     # via
@@ -137,7 +137,7 @@ pyjwt[crypto]==2.10.1
     #   -r requirements/base.txt
     #   drf-jwt
     #   edx-drf-extensions
-pymongo==4.12.0
+pymongo==4.13.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -206,7 +206,7 @@ urllib3==2.2.3
     #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
     #   requests
-web-fragments==3.0.0
+web-fragments==3.1.0
     # via
     #   -r requirements/base.txt
     #   xblock

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,311}-django{42}, pii_check, quality, docs
+envlist = py{311,312}-django{42}, pii_check, quality, docs
 
 [doc8]
 max-line-length = 120


### PR DESCRIPTION
Resolves #271 

- Updated Python version in tox
- Bumped actions/checkout to v4
- Bumped actions/setup-python to v5
- Fixed Pylint issues
- Updated Requirements and changelog



