### PR TITLE
fix: Fixes CI test for failing migration

### DIFF
--- a/.github/workflows/migrations-checker-postgresql.yml
+++ b/.github/workflows/migrations-checker-postgresql.yml
@@ -57,7 +57,11 @@ jobs:
       - name: Install Dependencies
         run: |
           pip install -r requirements/ci.txt
-          pip install -r requirements/test.txt
+          # We need the -c here explicitly because we drop the django version from test.txt so that
+          # tox can manage it. Since, tox is not installing dependencies here,
+          # we need a way to manage the django and drf version for
+          # compatibility.
+          pip install -c requirements/constraints.txt -r requirements/test.txt
           pip install mysqlclient
           pip install psycopg2-binary
       - name: Apply Postgresql Migrations


### PR DESCRIPTION
## Description

Fixes the migration check in the CI

## Supporting information

From past few days the PRs are facing issue of failing CI checks which are happening because of DRF and Django version mismatch.

## Testing instructions

Check CI

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.
